### PR TITLE
doc: recommendation table format

### DIFF
--- a/govgen-1/README.md
+++ b/govgen-1/README.md
@@ -70,9 +70,9 @@ $ md5sum ~/.govgen/config/genesis.json
 ```
 
 ### Recommendations
-
-| minimum-gas-prices | 0.001ugovgen                                         |
+| | |
 |--------------------|------------------------------------------------------|
+| minimum-gas-prices | 0.001ugovgen                                         |
 | seeds              | see [./seeds.txt](./seeds.txt)                       |
 | persistent_peers   | see [./persistent_peers.txt](./persistent_peers.txt) |
 


### PR DESCRIPTION
Remove the `minimum-pas-price` as a table header, which was confusing.

Unfortunately it seems not possible to render a markdown table w/o a header, so the change just add an empty header.